### PR TITLE
refactor: placement of read tag for Add new tool

### DIFF
--- a/app/(home)/index.tsx
+++ b/app/(home)/index.tsx
@@ -20,26 +20,14 @@ const HomeScreen = () => {
   const { styles } = useStyles(_styles);
   const bottomSheetRef = useRef<BottomSheet>(null);
   const [isBottomSheetVisible, setIsBottomSheetVisible] = useState(false);
-  const [isAddingTool, setIsAddingTool] = useState(false);
   const [isScanningTool, setIsScanningTool] = useState(false);
 
   // Memoize snapPoints
   const snapPoints = useMemo(() => ['45%'], []);
 
   const handleCreateTool = useCallback(() => {
-    if (isAddingTool) return;
-
-    setIsAddingTool(true);
-    setIsBottomSheetVisible(true);
-    bottomSheetRef.current?.expand();
-
-    setTimeout(() => {
-      setIsBottomSheetVisible(false);
-      bottomSheetRef.current?.close();
-      router.push('/add-tool');
-      setIsAddingTool(false);
-    }, 4000);
-  }, [isAddingTool]);
+    router.push('/add-tool');
+  }, []);
 
   const handleScanTool = useCallback(() => {
     if (isScanningTool) return;
@@ -79,7 +67,7 @@ const HomeScreen = () => {
               <Text style={styles.label}>Scan Tool</Text>
             </Pressable>
 
-            <Pressable style={styles.action} onPress={handleCreateTool} disabled={isAddingTool}>
+            <Pressable style={styles.action} onPress={handleCreateTool}>
               <AddTool style={styles.icon} />
 
               <Text style={styles.label}>Add New Tool</Text>

--- a/modules/my-tools/tool.tsx
+++ b/modules/my-tools/tool.tsx
@@ -1,7 +1,9 @@
-import { View, Text, Image, Pressable } from 'react-native';
-import React from 'react';
-import { createStyleSheet, useStyles } from 'react-native-unistyles';
 import { useRouter } from 'expo-router';
+import React from 'react';
+import { Image, Pressable } from 'react-native';
+import { createStyleSheet, useStyles } from 'react-native-unistyles';
+
+import { View, Text } from '~/components/shared';
 
 export type TOOL_STATUS = 'available' | 'unavailable';
 export interface ToolProps {
@@ -15,7 +17,7 @@ export interface ToolProps {
 
 const Tool = ({ id, category, description, lastUsed, status, title }: ToolProps) => {
   const { styles } = useStyles(_style);
-  const isAvailable = status == 'available';
+  const isAvailable = status === 'available';
   const router = useRouter();
   const goToDetailsScreen = () => {
     router.navigate(`/my-tools/${id}`);
@@ -25,7 +27,7 @@ const Tool = ({ id, category, description, lastUsed, status, title }: ToolProps)
       <Image
         resizeMode="contain"
         style={styles.toolImage}
-        source={require('../assets/images/tool.png')}
+        source={require('~/assets/images/tool.png')}
       />
       <View style={styles.toolContent}>
         <View style={styles.titleWrapper}>


### PR DESCRIPTION
This PR fixes the following: 

- Removes the bottomsheet scan tag component to add new tool from home screen
- Adds the scan tag component to after user adds new tool info in the add new tool screen
- Move react-native import in tool.tsx